### PR TITLE
Improvements to the exported libraries and connection names

### DIFF
--- a/.changeset/plenty-ducks-cheer.md
+++ b/.changeset/plenty-ducks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps-labs/reactor-mod-data-browser': major
+---
+
+Name of connection changed to an EntityDescription and also export shared db library

--- a/modules/module-data-browser/src/core/AbstractConnection.ts
+++ b/modules/module-data-browser/src/core/AbstractConnection.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 import { BaseObserver } from '@journeyapps-labs/common-utils';
 import { Collection, LifecycleCollection } from '@journeyapps-labs/lib-reactor-data-layer';
 import { when } from 'mobx';
+import { EntityDescription } from '@journeyapps-labs/reactor-mod';
 
 export interface AbstractConnectionSerialized {
   factory: string;
@@ -91,8 +92,10 @@ export abstract class AbstractConnection extends BaseObserver<AbstractConnection
     };
   }
 
-  get name() {
-    return this.id;
+  get name(): EntityDescription {
+    return {
+      simpleName: this.id
+    };
   }
 
   abstract _serialize(): any;

--- a/modules/module-data-browser/src/core/types/ManualConnection.ts
+++ b/modules/module-data-browser/src/core/types/ManualConnection.ts
@@ -1,6 +1,7 @@
 import { ApiCredentialOptions, Database } from '@journeyapps/db';
 import { AbstractConnection } from '../AbstractConnection';
 import { ManualConnectionFactory } from './ManualConnectionFactory';
+import { EntityDescription } from '@journeyapps-labs/reactor-mod';
 
 export interface ManualConnectionDetails extends ApiCredentialOptions {
   name: string;
@@ -26,7 +27,9 @@ export class ManualConnection extends AbstractConnection {
     this.options = data;
   }
 
-  get name(): string {
-    return this.options.name;
+  get name(): EntityDescription {
+    return {
+      simpleName: this.options.name
+    };
   }
 }

--- a/modules/module-data-browser/src/entities/ConnectionEntityDefinition.tsx
+++ b/modules/module-data-browser/src/entities/ConnectionEntityDefinition.tsx
@@ -1,6 +1,5 @@
 import {
   DescendantEntityProviderComponent,
-  EntityActionHandlerComponent,
   EntityDefinition,
   EntityDescriberComponent,
   EntityPanelComponent,
@@ -30,9 +29,7 @@ export class ConnectionEntityDefinition extends EntityDefinition<AbstractConnect
       new EntityDescriberComponent<AbstractConnection>({
         label: 'Simple',
         describe: (entity: AbstractConnection) => {
-          return {
-            simpleName: entity.name
-          };
+          return entity.name;
         }
       })
     );
@@ -69,6 +66,7 @@ export class ConnectionEntityDefinition extends EntityDefinition<AbstractConnect
       })
     );
   }
+
   matchEntity(t: any): boolean {
     if (t instanceof AbstractConnection) {
       return true;

--- a/modules/module-data-browser/webpack.config.js
+++ b/modules/module-data-browser/webpack.config.js
@@ -1,0 +1,8 @@
+const { patchExportedLibrary } = require('@journeyapps-labs/lib-reactor-builder');
+module.exports = (webpack) => {
+  return patchExportedLibrary({
+    w: webpack,
+    module: '@journeyapps/db',
+    dir: __dirname
+  });
+};

--- a/modules/module-data-browser/webpack.config.js
+++ b/modules/module-data-browser/webpack.config.js
@@ -3,6 +3,7 @@ module.exports = (webpack) => {
   return patchExportedLibrary({
     w: webpack,
     module: '@journeyapps/db',
-    dir: __dirname
+    dir: __dirname,
+    alias: true
   });
 };


### PR DESCRIPTION
* Connection name is now an `EntityDescription`
* Build system exports `@journeyapps/db` to fix `instanceof` checks downstream in Sector cloud edition